### PR TITLE
[BE & FE] 마이페이지 페이지 구현 (View + Api)

### DIFF
--- a/src/main/java/com/sjiwon/studyholic/common/CommonDateTranslator.java
+++ b/src/main/java/com/sjiwon/studyholic/common/CommonDateTranslator.java
@@ -1,0 +1,47 @@
+package com.sjiwon.studyholic.common;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public class CommonDateTranslator {
+    public static String translateLocalDateTimeToStringVersion1(LocalDateTime date) {
+        return date.getYear() + "년 " +
+                date.getMonth().getValue() + "월 " +
+                date.getDayOfMonth() + "일";
+    }
+
+    public static String translateLocalDateTimeToStringVersion2(LocalDateTime date) {
+        return date.getYear() + "년 " +
+                date.getMonth().getValue() + "월 " +
+                date.getDayOfMonth() + "일 " +
+                date.getHour() + "시 " +
+                date.getMinute() + "분";
+    }
+
+    public static String translateLocalDateToString(LocalDate date) {
+        return date.getYear() + "년 " +
+                date.getMonth().getValue() + "월 " +
+                date.getDayOfMonth() + "일";
+    }
+
+    public static String translateRegisterDateFromCurrentDate(LocalDateTime date) {
+        LocalDateTime currentDate = LocalDateTime.now();
+
+        long hour = ChronoUnit.HOURS.between(date, currentDate);
+        long minute = ChronoUnit.MINUTES.between(date, currentDate);
+        long second = ChronoUnit.SECONDS.between(date, currentDate);
+
+        if (second < 60) {
+            return second + "초 전";
+        } else if (minute < 60) {
+            return minute + "분 전";
+        } else if (hour < 24) {
+            return hour + "시간 전";
+        } else {
+            return date.getYear() + "년 " +
+                    date.getMonth().getValue() + "월 " +
+                    date.getDayOfMonth() + "일";
+        }
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/UserRepository.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long>, UserQueryDslR
     boolean existsByNickName(String nickName);
     boolean existsByLoginId(String loginId);
     boolean existsByEmail(String Email);
+    boolean existsByIdNotAndNickName(Long userId, String nickName);
 }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/dsl/UserQueryDslRepository.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/dsl/UserQueryDslRepository.java
@@ -1,4 +1,9 @@
 package com.sjiwon.studyholic.domain.entity.user.repository.dsl;
 
+import com.sjiwon.studyholic.domain.entity.user.repository.dto.BasicUser;
+
+import java.util.Optional;
+
 public interface UserQueryDslRepository {
+    Optional<BasicUser> getBasicUserInformation(Long userId);
 }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/dsl/UserQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/dsl/UserQueryDslRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.sjiwon.studyholic.domain.entity.user.repository.dsl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sjiwon.studyholic.domain.entity.user.repository.dto.BasicUser;
+import com.sjiwon.studyholic.domain.entity.user.repository.dto.QBasicUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.sjiwon.studyholic.domain.entity.user.QUser.user;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserQueryDslRepositoryImpl implements UserQueryDslRepository {
+    private final JPAQueryFactory query;
+
+    /**
+     * 마이페이지 정보 조회 쿼리
+     */
+    @Override
+    public Optional<BasicUser> getBasicUserInformation(Long userId) {
+        return Optional.ofNullable(
+                query.select(new QBasicUser(user.id, user.name, user.nickName, user.loginId, user.loginPassword, user.email, user.birth, user.joinDate, user.storageName, user.lastModifiedDate))
+                        .from(user)
+                        .where(userIdEq(userId))
+                        .fetchFirst()
+        );
+    }
+
+    private BooleanExpression userIdEq(Long userId) {
+        if (Objects.isNull(userId)) {
+            return null;
+        }
+
+        return user.id.eq(userId);
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/dto/BasicUser.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/repository/dto/BasicUser.java
@@ -1,0 +1,38 @@
+package com.sjiwon.studyholic.domain.entity.user.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BasicUser {
+    private Long id;
+    private String name;
+    private String nickname;
+    private String loginId;
+    private String loginPassword;
+    private LocalDate birth;
+    private String email;
+    private LocalDateTime joinDate;
+    private String profileImage;
+    private LocalDateTime lastModifiedDate;
+
+    @QueryProjection
+    public BasicUser(Long id, String name, String nickname, String loginId, String loginPassword, String email, LocalDate birth, LocalDateTime joinDate, String profileImage, LocalDateTime lastModifiedDate) {
+        this.id = id;
+        this.name = name;
+        this.nickname = nickname;
+        this.loginId = loginId;
+        this.loginPassword = loginPassword;
+        this.birth = birth;
+        this.email = email;
+        this.joinDate = joinDate;
+        this.profileImage = profileImage;
+        this.lastModifiedDate = lastModifiedDate;
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
@@ -81,6 +81,27 @@ public class UserService {
         }
     }
 
+    @Transactional
+    public void changeUserNickname(Long userId, String updateNickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> StudyholicException.type(USER_NOT_FOUND));
+        isSameNicknameAsBefore(user.getNickName(), updateNickname);
+        isDuplicateNickname(userId, updateNickname);
+        user.changeNickname(updateNickname);
+    }
+
+    private void isSameNicknameAsBefore(String beforeNickname, String afterNickname) {
+        if (Objects.equals(beforeNickname, afterNickname)) {
+            throw StudyholicException.type(SAME_USER_NICKNAME_AS_BEFORE);
+        }
+    }
+
+    private void isDuplicateNickname(Long userId, String nickname) {
+        if (userRepository.existsByIdNotAndNickName(userId, nickname)) {
+            throw StudyholicException.type(DUPLICATE_USER_NICKNAME);
+        }
+    }
+
     /**
      * View를 위한 Service Logic
      */

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
@@ -61,6 +61,16 @@ public class UserService {
         fileUploadService.uploadProfileImage(profile, user);
     }
 
+    @Transactional
+    public void changeUserProfileImageToDefault(Long requestUserId, HttpServletRequest request) {
+        Long currentUserId = getCurrentUserSession(request).getId();
+        isIllegalRequestByAnonymousUser(requestUserId, currentUserId);
+
+        User user = userRepository.findById(requestUserId)
+                .orElseThrow(() -> StudyholicException.type(USER_NOT_FOUND));
+        user.applyDefaultImage();
+    }
+
     private UserSession getCurrentUserSession(HttpServletRequest request) {
         return (UserSession) request.getSession(false).getAttribute(SESSION_KEY);
     }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.sjiwon.studyholic.domain.entity.user.User;
 import com.sjiwon.studyholic.domain.entity.user.repository.UserRepository;
 import com.sjiwon.studyholic.domain.entity.user.service.dto.response.MyPageInformation;
 import com.sjiwon.studyholic.domain.etc.file.FileUploadService;
+import com.sjiwon.studyholic.domain.etc.login.dto.response.UserSession;
 import com.sjiwon.studyholic.exception.StudyholicException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
@@ -11,8 +12,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
 
+import static com.sjiwon.studyholic.common.VariableFactory.SESSION_KEY;
 import static com.sjiwon.studyholic.exception.StudyholicErrorCode.*;
 
 @Service
@@ -45,6 +48,26 @@ public class UserService {
     public void hasDuplicateLoginId(String loginId) {
         if (userRepository.existsByLoginId(loginId)) {
             throw StudyholicException.type(DUPLICATE_USER_LOGIN_ID);
+        }
+    }
+
+    @Transactional
+    public void changeUserProfileImage(Long requestUserId, MultipartFile profile, HttpServletRequest request) {
+        Long currentUserId = getCurrentUserSession(request).getId();
+        isIllegalRequestByAnonymousUser(requestUserId, currentUserId);
+
+        User user = userRepository.findById(requestUserId)
+                .orElseThrow(() -> StudyholicException.type(USER_NOT_FOUND));
+        fileUploadService.uploadProfileImage(profile, user);
+    }
+
+    private UserSession getCurrentUserSession(HttpServletRequest request) {
+        return (UserSession) request.getSession(false).getAttribute(SESSION_KEY);
+    }
+
+    private void isIllegalRequestByAnonymousUser(Long requestUserId, Long currentUserId) {
+        if (!Objects.equals(requestUserId, currentUserId)) {
+            throw StudyholicException.type(ILLEGAL_REQUEST_BY_ANONYMOUS);
         }
     }
 

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.sjiwon.studyholic.domain.entity.user.service;
 
 import com.sjiwon.studyholic.domain.entity.user.User;
 import com.sjiwon.studyholic.domain.entity.user.repository.UserRepository;
+import com.sjiwon.studyholic.domain.entity.user.service.dto.response.MyPageInformation;
 import com.sjiwon.studyholic.domain.etc.file.FileUploadService;
 import com.sjiwon.studyholic.exception.StudyholicException;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Objects;
 
-import static com.sjiwon.studyholic.exception.StudyholicErrorCode.DUPLICATE_USER_LOGIN_ID;
-import static com.sjiwon.studyholic.exception.StudyholicErrorCode.DUPLICATE_USER_NICKNAME;
+import static com.sjiwon.studyholic.exception.StudyholicErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -46,5 +46,15 @@ public class UserService {
         if (userRepository.existsByLoginId(loginId)) {
             throw StudyholicException.type(DUPLICATE_USER_LOGIN_ID);
         }
+    }
+
+    /**
+     * View를 위한 Service Logic
+     */
+    public MyPageInformation getUserDetailInformation(Long userId) {
+        return new MyPageInformation(
+                userRepository.getBasicUserInformation(userId)
+                        .orElseThrow(() -> StudyholicException.type(USER_NOT_FOUND))
+        );
     }
 }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/dto/response/MyPageInformation.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/user/service/dto/response/MyPageInformation.java
@@ -1,0 +1,37 @@
+package com.sjiwon.studyholic.domain.entity.user.service.dto.response;
+
+import com.sjiwon.studyholic.common.CommonDateTranslator;
+import com.sjiwon.studyholic.domain.entity.user.repository.dto.BasicUser;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MyPageInformation {
+    private Long userId;
+    private String userName;
+    private String userNickname;
+    private String userLoginId;
+    private String userLoginPassword;
+    private String userBirth;
+    private String userEmail;
+    private String userJoinDate;
+    private String userProfileImage;
+    private String userLastModifiedDate;
+
+    public MyPageInformation(BasicUser user) {
+        this.userId = user.getId();
+        this.userName = user.getName();
+        this.userNickname = user.getNickname();
+        this.userLoginId = user.getLoginId();
+        this.userLoginPassword = user.getLoginPassword();
+        this.userBirth = CommonDateTranslator.translateLocalDateToString(user.getBirth());
+        this.userEmail = user.getEmail();
+        this.userJoinDate = CommonDateTranslator.translateLocalDateTimeToStringVersion1(user.getJoinDate());
+        this.userProfileImage = user.getProfileImage();
+        this.userLastModifiedDate = CommonDateTranslator.translateLocalDateTimeToStringVersion2(user.getLastModifiedDate());
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/etc/session/SessionRefreshService.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/etc/session/SessionRefreshService.java
@@ -1,0 +1,30 @@
+package com.sjiwon.studyholic.domain.etc.session;
+
+import com.sjiwon.studyholic.domain.entity.user.User;
+import com.sjiwon.studyholic.domain.entity.user.repository.UserRepository;
+import com.sjiwon.studyholic.domain.etc.login.dto.response.UserSession;
+import com.sjiwon.studyholic.exception.StudyholicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import static com.sjiwon.studyholic.common.VariableFactory.SESSION_KEY;
+import static com.sjiwon.studyholic.exception.StudyholicErrorCode.USER_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SessionRefreshService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void refreshSession(Long userId, HttpServletRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> StudyholicException.type(USER_NOT_FOUND));
+        HttpSession session = request.getSession();
+        session.setAttribute(SESSION_KEY, UserSession.of(user));
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/exception/StudyholicErrorCode.java
+++ b/src/main/java/com/sjiwon/studyholic/exception/StudyholicErrorCode.java
@@ -12,6 +12,7 @@ public enum StudyholicErrorCode {
     DUPLICATE_USER_LOGIN_ID(HttpStatus.CONFLICT, "중복된 로그인 아이디입니다"),
     DUPLICATE_USER_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다"),
     EMAIL_NEVER_AUTHENTICATED(HttpStatus.CONFLICT, "인증내역이 없는 이메일입니다"),
+    ILLEGAL_REQUEST_BY_ANONYMOUS(HttpStatus.BAD_REQUEST, "타인의 정보에 접근할 수 없습니다"),
 
     ;
 

--- a/src/main/java/com/sjiwon/studyholic/exception/StudyholicErrorCode.java
+++ b/src/main/java/com/sjiwon/studyholic/exception/StudyholicErrorCode.java
@@ -13,6 +13,7 @@ public enum StudyholicErrorCode {
     DUPLICATE_USER_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다"),
     EMAIL_NEVER_AUTHENTICATED(HttpStatus.CONFLICT, "인증내역이 없는 이메일입니다"),
     ILLEGAL_REQUEST_BY_ANONYMOUS(HttpStatus.BAD_REQUEST, "타인의 정보에 접근할 수 없습니다"),
+    SAME_USER_NICKNAME_AS_BEFORE(HttpStatus.CONFLICT, "이전과 동일한 닉네임은 사용 불가능합니다"),
 
     ;
 

--- a/src/main/java/com/sjiwon/studyholic/web/api/user/UserApiController.java
+++ b/src/main/java/com/sjiwon/studyholic/web/api/user/UserApiController.java
@@ -1,6 +1,8 @@
 package com.sjiwon.studyholic.web.api.user;
 
 import com.sjiwon.studyholic.domain.entity.user.service.UserService;
+import com.sjiwon.studyholic.domain.etc.session.SessionRefreshService;
+import com.sjiwon.studyholic.web.api.user.dto.request.ChangeProfileRequest;
 import com.sjiwon.studyholic.web.api.user.dto.request.UserDuplicateCheckRequest;
 import com.sjiwon.studyholic.web.api.user.dto.request.UserJoinRequest;
 import com.sjiwon.studyholic.web.api.user.dto.request.UserJoinRequestWithDefaultProfile;
@@ -11,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 
 @RestController
@@ -19,6 +22,7 @@ import java.net.URI;
 @Api(tags = {"사용자 API"})
 public class UserApiController {
     private final UserService userService;
+    private final SessionRefreshService sessionRefreshService;
 
     @PostMapping(value = "/user", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ApiOperation(value = "회원가입 API - Version 1", notes = "회원가입을 위한 API (사용자가 업로드한 이미지로 프로필 적용)")
@@ -32,6 +36,14 @@ public class UserApiController {
     public ResponseEntity<Void> joinUserWithDefaultProfile(@ModelAttribute UserJoinRequestWithDefaultProfile request) {
         Long joinUserId = userService.saveUser(request.toEntity(), null);
         return ResponseEntity.created(URI.create("/user/" + joinUserId)).build();
+    }
+
+    @PatchMapping(value = "/user/change-profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ApiOperation(value = "사용자 프로필 이미지 변경 API - Version 1", notes = "사용자의 현재 프로필 이미지를 새로 업로드하는 이미지로 변경하는 API")
+    public ResponseEntity<Void> changeUserProfileImage(@ModelAttribute ChangeProfileRequest changeRequest, HttpServletRequest request) {
+        userService.changeUserProfileImage(changeRequest.getUserId(), changeRequest.getProfile(), request);
+        sessionRefreshService.refreshSession(changeRequest.getUserId(), request);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/user/duplicate-check")

--- a/src/main/java/com/sjiwon/studyholic/web/api/user/UserApiController.java
+++ b/src/main/java/com/sjiwon/studyholic/web/api/user/UserApiController.java
@@ -2,10 +2,7 @@ package com.sjiwon.studyholic.web.api.user;
 
 import com.sjiwon.studyholic.domain.entity.user.service.UserService;
 import com.sjiwon.studyholic.domain.etc.session.SessionRefreshService;
-import com.sjiwon.studyholic.web.api.user.dto.request.ChangeProfileRequest;
-import com.sjiwon.studyholic.web.api.user.dto.request.UserDuplicateCheckRequest;
-import com.sjiwon.studyholic.web.api.user.dto.request.UserJoinRequest;
-import com.sjiwon.studyholic.web.api.user.dto.request.UserJoinRequestWithDefaultProfile;
+import com.sjiwon.studyholic.web.api.user.dto.request.*;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +48,14 @@ public class UserApiController {
     public ResponseEntity<Void> changeUserProfileImageToDefault(@RequestParam Long userId, HttpServletRequest request) {
         userService.changeUserProfileImageToDefault(userId, request);
         sessionRefreshService.refreshSession(userId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/user/change-nickname")
+    @ApiOperation(value = "사용자 닉네임 변경 API", notes = "닉네임을 변경하기 위한 API")
+    public ResponseEntity<Void> changeUserNickname(@RequestBody ChangeNicknameRequest changeRequest, HttpServletRequest request) {
+        userService.changeUserNickname(changeRequest.getUserId(), changeRequest.getNickname());
+        sessionRefreshService.refreshSession(changeRequest.getUserId(), request);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/sjiwon/studyholic/web/api/user/UserApiController.java
+++ b/src/main/java/com/sjiwon/studyholic/web/api/user/UserApiController.java
@@ -46,6 +46,14 @@ public class UserApiController {
         return ResponseEntity.noContent().build();
     }
 
+    @PatchMapping("/user/change-default-profile")
+    @ApiOperation(value = "사용자 프로필 이미지 변경 API - Version 2", notes = "사용자의 현재 프로필 이미지를 서버 기본 제공 이미지로 변경하는 API")
+    public ResponseEntity<Void> changeUserProfileImageToDefault(@RequestParam Long userId, HttpServletRequest request) {
+        userService.changeUserProfileImageToDefault(userId, request);
+        sessionRefreshService.refreshSession(userId, request);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/user/duplicate-check")
     @ApiOperation(value = "사용자 중복 체크 API", notes = "회원가입 간 데이터 중복 체크를 위한 API [닉네임, 아이디]")
     public ResponseEntity<Void> checkUserDuplicateResource(@RequestBody UserDuplicateCheckRequest checkRequest) {

--- a/src/main/java/com/sjiwon/studyholic/web/api/user/dto/request/ChangeNicknameRequest.java
+++ b/src/main/java/com/sjiwon/studyholic/web/api/user/dto/request/ChangeNicknameRequest.java
@@ -1,0 +1,18 @@
+package com.sjiwon.studyholic.web.api.user.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChangeNicknameRequest {
+    @ApiModelProperty(value = "정보 변경할 사용자 ID(PK)", example = "1", required = true)
+    private Long userId;
+
+    @ApiModelProperty(value = "변경할 닉네임", example = "Hello World", required = true)
+    private String nickname;
+}

--- a/src/main/java/com/sjiwon/studyholic/web/api/user/dto/request/ChangeProfileRequest.java
+++ b/src/main/java/com/sjiwon/studyholic/web/api/user/dto/request/ChangeProfileRequest.java
@@ -1,0 +1,17 @@
+package com.sjiwon.studyholic.web.api.user.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChangeProfileRequest {
+    @ApiModelProperty(value = "정보 변경할 사용자 ID(PK)", example = "1", required = true)
+    private Long userId;
+
+    @ApiModelProperty(value = "변경할 프로필 이미지", required = true)
+    private MultipartFile profile;
+}

--- a/src/main/java/com/sjiwon/studyholic/web/view/ViewController.java
+++ b/src/main/java/com/sjiwon/studyholic/web/view/ViewController.java
@@ -1,12 +1,26 @@
 package com.sjiwon.studyholic.web.view;
 
+import com.sjiwon.studyholic.domain.entity.user.service.UserService;
+import com.sjiwon.studyholic.domain.etc.login.dto.response.UserSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Objects;
+
+import static com.sjiwon.studyholic.common.VariableFactory.SESSION_KEY;
 
 @Controller
 @RequiredArgsConstructor
 public class ViewController {
+    private final UserService userService;
+
     @GetMapping("/login")
     public String loginPage() {
         return "authenticate/LoginPage";
@@ -15,5 +29,25 @@ public class ViewController {
     @GetMapping("/signup")
     public String signUpPage() {
         return "authenticate/SignUpPage";
+    }
+
+    @GetMapping("/user/{userId}")
+    public String myPage(@PathVariable Long userId, HttpServletRequest request, HttpServletResponse response, Model model) throws IOException {
+        delegateIllegalUrlRequest(userId, request, response);
+        model.addAttribute("userDetail", userService.getUserDetailInformation(userId));
+        return "main/MyPage";
+    }
+
+    private void delegateIllegalUrlRequest(Long userId, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (!Objects.equals(getUserSession(request).getId(), userId)) {
+            response.setContentType("text/html; charset=UTF-8");
+            PrintWriter writer = response.getWriter();
+            writer.println("<script>alert('올바르지 않은 요청입니다'); location.href = '/';</script>");
+            writer.flush();
+        }
+    }
+
+    private UserSession getUserSession(HttpServletRequest request) {
+        return (UserSession) request.getSession(false).getAttribute(SESSION_KEY);
     }
 }

--- a/src/main/resources/static/js/user/EditUser.js
+++ b/src/main/resources/static/js/user/EditUser.js
@@ -1,0 +1,109 @@
+// 1. 기본 이미지로 변경
+function editProfileToDefaultImage() {
+    let userId = $('#userId');
+
+    let select = confirm('기본 이미지로 변경하시겠습니까?');
+    if (select) {
+        axios.patch('/api/user/change-default-profile?userId=' + userId.val())
+            .then(() => {
+                alert('프로필 변경이 완료되었습니다');
+                location.href = '/user/' + userId.val();
+            })
+            .catch(error => {
+                let jsonData = error.response.data;
+                alert(jsonData['message']);
+            });
+    } else {
+        return false;
+    }
+}
+
+// 2. 커스텀 이미지로 변경
+function editProfileToCustomImage() {
+    let userId = $('#userId');
+    let image = document.getElementById('image');
+
+    if (image.files.length === 0) {
+        alert('파일을 업로드하고 변경 버튼을 눌러주세요');
+        return false;
+    }
+
+
+    let select = confirm('선택하신 이미지로 변경하시겠습니까?');
+    if (select) {
+        let formData = new FormData();
+        formData.append('userId', userId.val());
+        formData.append('profile', image.files[0]);
+
+        let fileExistsAxiosConfig = {
+            headers: {
+                "Content-Type": "multipart/form-data",
+            }
+        };
+
+        axios.patch('/api/user/change-profile', formData, fileExistsAxiosConfig)
+            .then(() => {
+                alert('프로필 변경이 완료되었습니다');
+                location.href = '/user/' + userId.val();
+            })
+            .catch(error => {
+                let jsonData = error.response.data;
+                alert(jsonData['message']);
+            });
+    } else {
+        return false;
+    }
+}
+
+// 3-1. 닉네임 변경 버튼 활성화
+function editNicknameButtonEnable() {
+    let nickname = $('#nickname');
+    let nicknameEditButton = $('#nicknameEditButton');
+
+    nickname.attr('readonly', false);
+    nicknameEditButton.html('완료');
+    nicknameEditButton.removeAttr('onclick');
+    nicknameEditButton.attr('onclick', 'editNicknameProcess()');
+}
+
+// 3-2. 닉네임 변경 프로세스
+function editNicknameProcess() {
+    let userId = $('#userId');
+    let nickname = $('#nickname');
+
+    if (nickname.val().trim() === '') {
+        alert('변경할 닉네임을 입력해주세요');
+        return false;
+    }
+
+    let select = confirm('[' + nickname.val() + ']로 변경하시겠습니까?');
+    if (select) {
+        let data = {
+            'userId': userId.val(),
+            'nickname': nickname.val()
+        };
+
+        axios.patch('/api/user/change-nickname', data)
+            .then(() => {
+                alert('닉네임 변경이 완료되었습니다');
+                location.href = '/user/' + userId.val();
+            })
+            .catch(error => {
+                let jsonData = error.response.data;
+                alert(jsonData['message']);
+            });
+    } else {
+        return false;
+    }
+}
+
+// 4. 비밀번호 재설정 페이지로 이동
+function moveToEditPasswordPage() {
+    let check = confirm('비밀번호 변경 페이지로 이동하시겠습니까?');
+
+    if (check) {
+        location.href = "/reset-password";
+    } else {
+        return false;
+    }
+}

--- a/src/main/webapp/WEB-INF/views/authenticate/LoginPage.jsp
+++ b/src/main/webapp/WEB-INF/views/authenticate/LoginPage.jsp
@@ -35,7 +35,7 @@
     </div>
 </main>
 <script>
-    $('#id, #password').on('keydown', function (event) {
+    $('#loginId, #loginPassword').on('keydown', function (event) {
         let key = event.key || event.keyCode;
 
         if (key === 'Enter' || key === 13) {

--- a/src/main/webapp/WEB-INF/views/fragment/Footer.jsp
+++ b/src/main/webapp/WEB-INF/views/fragment/Footer.jsp
@@ -1,0 +1,24 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<footer class="bg-light text-center text-white">
+    <!-- Copyright -->
+    <div class="text-center p-3" style="background-color: rgba(0, 0, 0, 0);">
+        <a class="text-black" href="https://github.com/sjiwon">© 2022 Copyright: Seo Ji Won</a><br>
+        <!-- Instagram -->
+        <a
+                class="btn text-white btn-floating m-1"
+                style="background-color: #ac2bac;"
+                href="https://www.instagram.com/sjiwon_/"
+                role="button"
+        ><i class="fab fa-instagram"></i
+        ></a>
+        <!-- Github -->
+        <a
+                class="btn text-white btn-floating m-1"
+                style="background-color: #333333;"
+                href="https://github.com/sjiwon"
+                role="button"
+        ><i class="fab fa-github"></i
+        ></a>
+    </div>
+    <!-- Copyright -->
+</footer>

--- a/src/main/webapp/WEB-INF/views/main/MyPage.jsp
+++ b/src/main/webapp/WEB-INF/views/main/MyPage.jsp
@@ -1,0 +1,104 @@
+<%@ page import="java.util.UUID" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Studyholic</title>
+    <%@ include file="../util/resources.jsp" %>
+    <script src="<c:url value="/js/user/EditUser.js"/>"></script>
+</head>
+<body>
+<c:choose>
+    <c:when test="${sessionScope.KGU_JSP_PROJECT == null}">
+        <jsp:include page="../fragment/AnonymousHeader.jsp"/>
+    </c:when>
+    <c:when test="${sessionScope.KGU_JSP_PROJECT != null}">
+        <jsp:include page="../fragment/AuthenticateHeader.jsp"/>
+    </c:when>
+</c:choose>
+
+<div class="container col-md-6">
+    <h1 style="text-align: center">마이페이지</h1>
+    <input type="hidden" id="userId" value="${userDetail.userId}"/>
+    <hr>
+    <div class="col-md-12">
+        <div class="col-md-6">
+            <img src="<c:out value="/images/user/${userDetail.userProfileImage}"/>" alt="test" width="130" height="130" style="border-radius: 25%; margin: 3px;"/>
+            <button class="btn btn-secondary btn-sm" type="button" onclick="editProfileToDefaultImage()">기본 이미지로 변경</button>
+        </div><br>
+        <div class="col-md-12 row">
+            <label for="image" class="form-label">프로필 변경</label>
+            <div class="col-md-10" style="margin-bottom: 5px;">
+                <input class="form-control" type="file" id="image">
+            </div>
+            <div class="col-md-2">
+                <button class="btn btn-danger btn-sm" type="button" onclick="editProfileToCustomImage()">변경</button>
+            </div>
+        </div><br>
+
+        <div class="card" style="border: 3px solid black">
+            <div class="card-body">
+                <div class="col-md-12 row">
+                    <div class="col-md-12">
+                        <label for="name" class="form-label">이름</label>
+                        <input class="form-control" type="text" id="name" value="${userDetail.userName}" readonly>
+                    </div>
+                </div><br>
+
+                <div class="col-md-12 row">
+                    <label for="nickname" class="form-label">닉네임</label>
+                    <div class="col-md-10" style="margin-bottom: 5px;">
+                        <input class="form-control" type="text" id="nickname" value="${userDetail.userNickname}" readonly>
+                    </div>
+                    <div class="col-md-2">
+                        <button id="nicknameEditButton" class="btn btn-danger btn-sm" type="button" onclick="editNicknameButtonEnable()">수정</button>
+                    </div>
+                </div><br>
+
+                <div class="col-md-12 row">
+                    <div class="col-md-12">
+                        <label for="loginId" class="form-label">아이디</label>
+                        <input class="form-control" type="text" id="loginId" value="${userDetail.userLoginId}" readonly>
+                    </div>
+                </div><br>
+
+                <div class="col-md-12 row">
+                    <label for="loginPassword" class="form-label">비밀번호</label>
+                    <div class="col-md-10" style="margin-bottom: 5px;">
+                        <input class="form-control" type="password" id="loginPassword" value="<%=UUID.randomUUID().toString()%>" readonly>
+                    </div>
+                    <div class="col-md-2">
+                        <button id="passwordEditButton" class="btn btn-danger btn-sm" type="button" onclick="moveToEditPasswordPage()">수정</button>
+                    </div>
+                </div><br>
+
+                <div class="col-md-12 row">
+                    <div class="col-md-12">
+                        <label for="birth" class="form-label">생년월일</label>
+                        <input class="form-control" type="text" id="birth" value="${userDetail.userBirth}" readonly>
+                    </div>
+                </div><br>
+
+                <div class="col-md-12 row">
+                    <div class="col-md-12">
+                        <label for="email" class="form-label">이메일</label>
+                        <input class="form-control" type="text" id="email" value="${userDetail.userEmail}" readonly>
+                    </div>
+                </div><br>
+
+                <hr>
+
+                <div style="margin-bottom: 10px; text-align: right">
+                    가입 날짜 | <small>${userDetail.userJoinDate}</small>
+                </div>
+                <div style="margin-bottom: 10px; text-align: right">
+                    최종 수정 날짜 | <small>${userDetail.userLastModifiedDate}</small>
+                </div>
+            </div>
+        </div>
+    </div>
+    <br>
+</div>
+<jsp:include page="../fragment/Footer.jsp"/>
+</body>
+</html>


### PR DESCRIPTION
## 마이페이지 구현 
- 마이페이지에서 필요한 데이터를 dto 스펙으로 정의하고 repository로부터 쿼리 조회 (QueryDsl)
- 프로필 이미지, 닉네임 변경 버튼 & 비밀번호 재설정 페이지 이동 버튼 구현

<br>

## 정보 수정 API
- 프로필 이미지 변경
    1. 서버 기본 제공 이미지
    2. 사용자 커스텀 업로드 이미지
 - 닉네임 변경
 - 비밀번호 수정 페이지로 이동
     - 이 부분은 따로 jsp 페이지를 생성해서 연동
  
<br>