### PR TITLE
[BE & FE] 메인 페이지 구현 (View + Api)

### DIFF
--- a/src/main/java/com/sjiwon/studyholic/common/VariableFactory.java
+++ b/src/main/java/com/sjiwon/studyholic/common/VariableFactory.java
@@ -1,5 +1,8 @@
 package com.sjiwon.studyholic.common;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class VariableFactory {
     public static final String SESSION_KEY = "KGU_JSP_PROJECT";
 
@@ -11,4 +14,24 @@ public class VariableFactory {
     public static final String RANDOM_PASSWORD_SUBJECT = "[Studyholic] 임시 비밀번호 발급";
     public static final String AUTHENTICATION_EMAIL_BODY = "인증번호";
     public static final String RANDOM_PASSWORD_EMAIL_BODY = "임시 비밀번호";
+
+    public static final int SIZE_PER_PAGE = 6; // 데이터 페이징 기준
+    public static final int RANGE_PER_PAGE = 10; // 페이지 상에서 range 범위
+
+    public static final String REGISTER_DATE_KO = "등록 날짜";
+    public static final String REGISTER_DATE_SORT = "registerDate";
+    public static final String POPULARITY_KO = "참여 인원";
+    public static final String POPULARITY_SORT = "popularity";
+    public static final String RECRUIT_DEADLINE_KO = "모집 마감일";
+    public static final String RECRUIT_DEADLINE_SORT = "recruitDeadline";
+    public static final String MAX_MEMBER_KO = "모집 정원";
+    public static final String MAX_MEMBER_SORT = "maxMember";
+    public static final Map<String, String> SORT_TO_KO = new HashMap<>() {
+        {
+            put(REGISTER_DATE_SORT, REGISTER_DATE_KO);
+            put(POPULARITY_SORT, POPULARITY_KO);
+            put(RECRUIT_DEADLINE_SORT, RECRUIT_DEADLINE_KO);
+            put(MAX_MEMBER_SORT, MAX_MEMBER_KO);
+        }
+    };
 }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/study/repository/dsl/StudyQueryDslRepository.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/study/repository/dsl/StudyQueryDslRepository.java
@@ -1,4 +1,10 @@
 package com.sjiwon.studyholic.domain.entity.study.repository.dsl;
 
+import com.sjiwon.studyholic.domain.entity.study.repository.dto.BasicStudy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface StudyQueryDslRepository {
+    Page<BasicStudy> getMainPageStudyList(Pageable pageRequest, String sort);
+    Page<BasicStudy> getMainPageStudyListWithKeyword(Pageable pageRequest, String sort, String keyword);
 }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/study/repository/dsl/StudyQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/study/repository/dsl/StudyQueryDslRepositoryImpl.java
@@ -1,0 +1,112 @@
+package com.sjiwon.studyholic.domain.entity.study.repository.dsl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sjiwon.studyholic.domain.entity.study.repository.dto.BasicStudy;
+import com.sjiwon.studyholic.domain.entity.study.repository.dto.QBasicStudy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.sjiwon.studyholic.common.VariableFactory.*;
+import static com.sjiwon.studyholic.domain.entity.study.QStudy.study;
+import static com.sjiwon.studyholic.domain.entity.studytag.QStudyTag.studyTag;
+import static com.sjiwon.studyholic.domain.entity.userstudy.QUserStudy.userStudy;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StudyQueryDslRepositoryImpl implements StudyQueryDslRepository {
+    private final JPAQueryFactory query;
+
+    @Override
+    public Page<BasicStudy> getMainPageStudyList(Pageable pageRequest, String sort) {
+        JPAQuery<BasicStudy> beforeOrderByQuery = query
+                .select(new QBasicStudy(
+                        study.id, study.name, study.briefDescription, study.description, study.maxMember, study.registerDate, study.recruitDeadLine, study.lastModifiedDate, study.userStudyList.size()))
+                .from(study)
+                .leftJoin(study.userStudyList, userStudy)
+                .groupBy(study.id, study.name, study.briefDescription, study.description, study.maxMember, study.registerDate, study.recruitDeadLine)
+                .offset((long) pageRequest.getPageNumber() * pageRequest.getPageSize())
+                .limit(pageRequest.getPageSize());
+
+        List<BasicStudy> content = switch (sort) {
+            case REGISTER_DATE_SORT ->  // 등록 날짜
+                    beforeOrderByQuery
+                            .orderBy(study.registerDate.desc(), study.userStudyList.size().desc())
+                            .fetch();
+            case POPULARITY_SORT ->  // 참여 인원
+                    beforeOrderByQuery
+                            .orderBy(study.userStudyList.size().desc(), study.recruitDeadLine.asc())
+                            .fetch();
+            case RECRUIT_DEADLINE_SORT ->  // 모집 마감일
+                    beforeOrderByQuery
+                            .orderBy(study.recruitDeadLine.asc(), study.userStudyList.size().desc())
+                            .fetch();
+            default ->  // 모집 정원
+                    beforeOrderByQuery
+                            .orderBy(study.maxMember.desc(), study.userStudyList.size().desc())
+                            .fetch();
+        };
+
+        List<Long> countQuery = query
+                .select(study.id)
+                .from(study)
+                .fetch();
+
+        return PageableExecutionUtils.getPage(content, pageRequest, countQuery::size);
+    }
+
+    @Override
+    public Page<BasicStudy> getMainPageStudyListWithKeyword(Pageable pageRequest, String sort, String keyword) {
+        JPAQuery<BasicStudy> beforeOrderByQuery = query
+                .select(new QBasicStudy(
+                        study.id, study.name, study.briefDescription, study.description, study.maxMember, study.registerDate, study.recruitDeadLine, study.lastModifiedDate, study.userStudyList.size()))
+                .from(study)
+                .leftJoin(study.studyTagList, studyTag)
+                .leftJoin(study.userStudyList, userStudy)
+                .where(keywordContains(keyword))
+                .groupBy(study.id, study.name, study.briefDescription, study.description, study.maxMember, study.registerDate, study.recruitDeadLine)
+                .offset((long) pageRequest.getPageNumber() * pageRequest.getPageSize())
+                .limit(pageRequest.getPageSize());
+
+        List<BasicStudy> content = switch (sort) {
+            case REGISTER_DATE_SORT ->  // 등록 날짜
+                    beforeOrderByQuery
+                            .orderBy(study.registerDate.desc())
+                            .fetch();
+            case POPULARITY_SORT ->  // 참여 인원
+                    beforeOrderByQuery
+                            .orderBy(study.userStudyList.size().desc())
+                            .fetch();
+            case RECRUIT_DEADLINE_SORT ->  // 모집 마감일
+                    beforeOrderByQuery
+                            .orderBy(study.recruitDeadLine.asc(), study.userStudyList.size().desc())
+                            .fetch();
+            default ->  // 모집 정원
+                    beforeOrderByQuery
+                            .orderBy(study.maxMember.desc(), study.userStudyList.size().desc())
+                            .fetch();
+        };
+
+        List<Long> countQuery = query
+                .select(study.id)
+                .from(study)
+                .fetch();
+
+        return PageableExecutionUtils.getPage(content, pageRequest, countQuery::size);
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        if (Objects.isNull(keyword)) {
+            return null;
+        }
+
+        return studyTag.tag.contains(keyword);
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/study/repository/dto/BasicStudy.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/study/repository/dto/BasicStudy.java
@@ -1,0 +1,33 @@
+package com.sjiwon.studyholic.domain.entity.study.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class BasicStudy {
+    private final Long id;
+    private final String name;
+    private final String briefDescription;
+    private final String description;
+    private final Integer maxMember;
+    private final LocalDateTime registerDate;
+    private final LocalDate recruitDeadLine;
+    private final LocalDateTime lastModifiedDate;
+    private final Integer currentMemberCount; // Sub Query
+
+    @QueryProjection
+    public BasicStudy(Long id, String name, String briefDescription, String description, Integer maxMember, LocalDateTime registerDate, LocalDate recruitDeadLine, LocalDateTime lastModifiedDate, Integer currentMemberCount) {
+        this.id = id;
+        this.name = name;
+        this.briefDescription = briefDescription;
+        this.description = description;
+        this.maxMember = maxMember;
+        this.currentMemberCount = currentMemberCount;
+        this.registerDate = registerDate;
+        this.recruitDeadLine = recruitDeadLine;
+        this.lastModifiedDate = lastModifiedDate;
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/study/service/StudyService.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/study/service/StudyService.java
@@ -1,0 +1,75 @@
+package com.sjiwon.studyholic.domain.entity.study.service;
+
+import com.sjiwon.studyholic.domain.entity.study.repository.StudyRepository;
+import com.sjiwon.studyholic.domain.entity.study.repository.dto.BasicStudy;
+import com.sjiwon.studyholic.domain.entity.study.service.dto.StudyLeaderDto;
+import com.sjiwon.studyholic.domain.entity.study.service.dto.response.StudySimpleInformation;
+import com.sjiwon.studyholic.domain.entity.studytag.StudyTag;
+import com.sjiwon.studyholic.domain.entity.studytag.repository.StudyTagRepository;
+import com.sjiwon.studyholic.domain.entity.userstudy.UserStudy;
+import com.sjiwon.studyholic.domain.entity.userstudy.repository.UserStudyRepository;
+import com.sjiwon.studyholic.exception.StudyholicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.sjiwon.studyholic.exception.StudyholicErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyService {
+    private final StudyRepository studyRepository;
+    private final StudyTagRepository studyTagRepository;
+    private final UserStudyRepository userStudyRepository;
+
+    /**
+     * View를 위한 Service Logic
+     */
+    public Page<StudySimpleInformation> getMainPageStudyList(Pageable pageable, String sort, @Nullable String keyword) {
+        Page<BasicStudy> pagingStudyList;
+        if (Objects.isNull(keyword) || keyword.isBlank()) {
+            pagingStudyList = studyRepository.getMainPageStudyList(pageable, sort);
+        } else {
+            pagingStudyList = studyRepository.getMainPageStudyListWithKeyword(pageable, sort, keyword);
+        }
+
+        List<StudyTag> studyTagList = studyTagRepository.findAllWithFetchStudy();
+        List<UserStudy> userStudyList = userStudyRepository.findAllWithFetchUserAndStudy();
+        List<StudySimpleInformation> studySimpleInformationList = pagingStudyList
+                .stream()
+                .map(basicStudyInformation -> new StudySimpleInformation(
+                        basicStudyInformation,
+                        getStudyTagList(studyTagList, basicStudyInformation),
+                        getStudyLeaderInformation(userStudyList, basicStudyInformation.getId())
+                ))
+                .collect(Collectors.toList());
+
+        return PageableExecutionUtils.getPage(studySimpleInformationList, pageable, pagingStudyList::getTotalElements);
+    }
+
+    private List<String> getStudyTagList(List<StudyTag> studyTagList, BasicStudy basicStudy) {
+        return studyTagList
+                .stream()
+                .filter(studyTag -> studyTag.getStudy().getId().equals(basicStudy.getId()))
+                .map(StudyTag::getTag)
+                .collect(Collectors.toList());
+    }
+
+    private StudyLeaderDto getStudyLeaderInformation(List<UserStudy> userStudyList, Long studyId) {
+        return userStudyList
+                .stream()
+                .filter(userStudy -> userStudy.getStudy().getId().equals(studyId) && userStudy.isTeamLeader())
+                .map(userStudy -> new StudyLeaderDto(userStudy.getUser()))
+                .findFirst()
+                .orElseThrow(() -> StudyholicException.type(USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/study/service/dto/StudyLeaderDto.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/study/service/dto/StudyLeaderDto.java
@@ -1,0 +1,24 @@
+package com.sjiwon.studyholic.domain.entity.study.service.dto;
+
+import com.sjiwon.studyholic.domain.entity.user.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class StudyLeaderDto {
+    private Long studyLeaderId; // 스터디 리더 ID (PK)
+    private String studyLeaderName; // 스터디 리더 이름
+    private String studyLeaderNickname; // 스터디 리더 닉네임
+    private String studyLeaderImage; // 스티더 리더 이미지 (서버 저장 이름)
+
+    public StudyLeaderDto(User user) {
+        this.studyLeaderId = user.getId();
+        this.studyLeaderName = user.getName();
+        this.studyLeaderNickname = user.getNickName();
+        this.studyLeaderImage = user.getStorageName();
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/study/service/dto/response/StudySimpleInformation.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/study/service/dto/response/StudySimpleInformation.java
@@ -1,0 +1,46 @@
+package com.sjiwon.studyholic.domain.entity.study.service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sjiwon.studyholic.common.CommonDateTranslator;
+import com.sjiwon.studyholic.domain.entity.study.repository.dto.BasicStudy;
+import com.sjiwon.studyholic.domain.entity.study.service.dto.StudyLeaderDto;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class StudySimpleInformation {
+    private final Long studyId; // 스터디 ID (PK)
+    private final String studyName; // 스터디 이름
+    private final String studyBriefDescription; // 스터디 간단 요약 설명
+    private final String studyDescription; // 스터디 설명
+    private final Integer studyMaxMemberCount; // 스터디 최대 정원
+    private final Integer studyCurrentMemberCount; // 스터디 현재 참가 인원 수
+    @JsonFormat(pattern = "yyyy년 MM월 dd일 HH시 mm분")
+    private final LocalDateTime studyRegisterDate; // 스터디 등록 날짜
+    private final String registerDateFromCurrentDate; // 현재 날짜로부터 얼마 전에 올렸는지
+    private final String studyRecruitDeadLine; // 스티더 모집 마감일
+    private final List<String> studyTagList; // 스터디 태그 리스트
+    private final Long studyLeaderId; // 스터디 리더 ID (PK)
+    private final String studyLeaderName; // 스터디 리더 이름
+    private final String studyLeaderNickname; // 스터디 리더 닉네임
+    private final String studyLeaderImage; // 스터디 리더 프로필 이미지 서버 저장 이름
+
+    public StudySimpleInformation(BasicStudy study, List<String> studyTagList, StudyLeaderDto studyLeader) {
+        this.studyId = study.getId();
+        this.studyName = study.getName();
+        this.studyBriefDescription = study.getBriefDescription();
+        this.studyDescription = study.getDescription();
+        this.studyMaxMemberCount = study.getMaxMember();
+        this.studyCurrentMemberCount = study.getCurrentMemberCount();
+        this.studyRegisterDate = study.getRegisterDate();
+        this.registerDateFromCurrentDate = CommonDateTranslator.translateRegisterDateFromCurrentDate(study.getRegisterDate());
+        this.studyRecruitDeadLine = CommonDateTranslator.translateLocalDateToString(study.getRecruitDeadLine());
+        this.studyTagList = studyTagList;
+        this.studyLeaderId = studyLeader.getStudyLeaderId();
+        this.studyLeaderName = studyLeader.getStudyLeaderName();
+        this.studyLeaderNickname = studyLeader.getStudyLeaderNickname();
+        this.studyLeaderImage = studyLeader.getStudyLeaderImage();
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/studytag/repository/dsl/StudyTagQueryDslRepository.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/studytag/repository/dsl/StudyTagQueryDslRepository.java
@@ -1,4 +1,9 @@
 package com.sjiwon.studyholic.domain.entity.studytag.repository.dsl;
 
+import com.sjiwon.studyholic.domain.entity.studytag.StudyTag;
+
+import java.util.List;
+
 public interface StudyTagQueryDslRepository {
+    List<StudyTag> findAllWithFetchStudy();
 }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/studytag/repository/dsl/StudyTagQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/studytag/repository/dsl/StudyTagQueryDslRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.sjiwon.studyholic.domain.entity.studytag.repository.dsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sjiwon.studyholic.domain.entity.studytag.StudyTag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.sjiwon.studyholic.domain.entity.study.QStudy.study;
+import static com.sjiwon.studyholic.domain.entity.studytag.QStudyTag.studyTag;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StudyTagQueryDslRepositoryImpl implements StudyTagQueryDslRepository {
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<StudyTag> findAllWithFetchStudy() {
+        return query
+                .select(studyTag)
+                .from(studyTag)
+                .innerJoin(studyTag.study, study).fetchJoin()
+                .orderBy(studyTag.tag.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/userstudy/repository/dsl/UserStudyQueryDslRepository.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/userstudy/repository/dsl/UserStudyQueryDslRepository.java
@@ -1,4 +1,9 @@
 package com.sjiwon.studyholic.domain.entity.userstudy.repository.dsl;
 
+import com.sjiwon.studyholic.domain.entity.userstudy.UserStudy;
+
+import java.util.List;
+
 public interface UserStudyQueryDslRepository {
+    List<UserStudy> findAllWithFetchUserAndStudy();
 }

--- a/src/main/java/com/sjiwon/studyholic/domain/entity/userstudy/repository/dsl/UserStudyQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sjiwon/studyholic/domain/entity/userstudy/repository/dsl/UserStudyQueryDslRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.sjiwon.studyholic.domain.entity.userstudy.repository.dsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sjiwon.studyholic.domain.entity.userstudy.UserStudy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.sjiwon.studyholic.domain.entity.userstudy.QUserStudy.userStudy;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserStudyQueryDslRepositoryImpl implements UserStudyQueryDslRepository {
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<UserStudy> findAllWithFetchUserAndStudy() {
+        return query
+                .select(userStudy)
+                .from(userStudy)
+                .innerJoin(userStudy.user).fetchJoin()
+                .innerJoin(userStudy.study).fetchJoin()
+                .fetch();
+    }
+}

--- a/src/main/java/com/sjiwon/studyholic/web/view/ViewController.java
+++ b/src/main/java/com/sjiwon/studyholic/web/view/ViewController.java
@@ -1,12 +1,18 @@
 package com.sjiwon.studyholic.web.view;
 
+import com.sjiwon.studyholic.domain.entity.study.service.StudyService;
+import com.sjiwon.studyholic.domain.entity.study.service.dto.response.StudySimpleInformation;
 import com.sjiwon.studyholic.domain.entity.user.service.UserService;
 import com.sjiwon.studyholic.domain.etc.login.dto.response.UserSession;
+import com.sjiwon.studyholic.web.view.dto.Pagination;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -14,12 +20,30 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Objects;
 
-import static com.sjiwon.studyholic.common.VariableFactory.SESSION_KEY;
+import static com.sjiwon.studyholic.common.VariableFactory.*;
 
 @Controller
 @RequiredArgsConstructor
 public class ViewController {
     private final UserService userService;
+    private final StudyService studyService;
+
+    @GetMapping({"", "/"})
+    public String mainPage(
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "registerDate") String sort,
+            @RequestParam(required = false) String keyword,
+            Model model
+    ) {
+        Page<StudySimpleInformation> studyList = studyService.getMainPageStudyList(PageRequest.of(page - 1, SIZE_PER_PAGE), sort, keyword);
+
+        model.addAttribute("searchType", SORT_TO_KO.get(sort));
+        model.addAttribute("keyword", keyword);
+        model.addAttribute("studyList", studyList.getContent());
+        model.addAttribute("pagination", new Pagination(studyList.getTotalElements(), studyList.getTotalPages(), page));
+
+        return "main/MainPage";
+    }
 
     @GetMapping("/login")
     public String loginPage() {

--- a/src/main/java/com/sjiwon/studyholic/web/view/dto/Pagination.java
+++ b/src/main/java/com/sjiwon/studyholic/web/view/dto/Pagination.java
@@ -1,0 +1,38 @@
+package com.sjiwon.studyholic.web.view.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.sjiwon.studyholic.common.VariableFactory.RANGE_PER_PAGE;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pagination {
+    private Long totalElements; // 전체 스터디 데이터 개수
+    private int totalPages; // 전체 페이지 개수
+    private int currentPage; // 현재 페이지
+    private int rangeStartNumber; // 현재 범위 시작 번호
+    private int rangeEndNumber; // 현재 범위 마지막 번호
+    private boolean prev; // 이전 range 존재 여부
+    private boolean next; // 다음 range 존재 여부
+
+    public Pagination(Long totalElements, int totalPages, int currentPage) {
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.currentPage = currentPage;
+
+        this.rangeStartNumber = RANGE_PER_PAGE * (currentPage / RANGE_PER_PAGE) + 1;
+        this.rangeEndNumber = RANGE_PER_PAGE * (currentPage / RANGE_PER_PAGE) + RANGE_PER_PAGE;
+
+        if (currentPage % RANGE_PER_PAGE == 0) {
+            rangeStartNumber = currentPage - (RANGE_PER_PAGE - 1);
+            rangeEndNumber = currentPage;
+        } else if (rangeEndNumber > totalPages) {
+            rangeEndNumber = totalPages;
+        }
+
+        this.prev = this.rangeStartNumber > RANGE_PER_PAGE;
+        this.next = this.rangeEndNumber + 1 <= totalPages;
+    }
+}

--- a/src/main/resources/static/js/paging/Paging.js
+++ b/src/main/resources/static/js/paging/Paging.js
@@ -1,0 +1,197 @@
+function movePreviousRange() {
+    let pageString = '';
+    let sortString = '';
+    let keywordString = '';
+
+    let search = location.search;
+    let queryList = search.split('&');
+
+    if (search.includes('page') && search.includes('sort') && search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+        let sortInfo = queryList[1].split('=')[1];
+        let keywordInfo = queryList[2].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (pageInfo - 19);
+        } else {
+            let number = Math.floor(pageInfo / 10 - 1);
+            pageString = (number === 0) ? '/?page=1' : '/?page=' + (number + '1');
+        }
+
+        sortString = '&sort=' + sortInfo;
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + sortString + keywordString;
+    } else if (search.includes('page') && !search.includes('sort') && search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+        let keywordInfo = queryList[1].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (pageInfo - 19);
+        } else {
+            let number = Math.floor(pageInfo / 10 - 1);
+            pageString = (number === 0) ? '/?page=1' : '/?page=' + (number + '1');
+        }
+
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + keywordString;
+    } else if (search.includes('page') && search.includes('sort') && !search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+        let sortInfo = queryList[1].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (pageInfo - 19);
+        } else {
+            let number = Math.floor(pageInfo / 10 - 1);
+            pageString = (number === 0) ? '/?page=1' : '/?page=' + (number + '1');
+        }
+
+        sortString = '&sort=' + sortInfo;
+        location.href = pageString + sortString;
+    } else if (search.includes('page') && !search.includes('sort') && !search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (pageInfo - 19);
+        } else {
+            let number = Math.floor(pageInfo / 10 - 1);
+            pageString = (number === 0) ? '/?page=1' : '/?page=' + (number + '1');
+        }
+
+        location.href = pageString;
+    }
+}
+
+function moveNextRange() {
+    let pageString = '';
+    let sortString = '';
+    let keywordString = '';
+
+    let search = location.search;
+    let queryList = search.split('&');
+
+    if (search.includes('page') && search.includes('sort') && search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+        let sortInfo = queryList[1].split('=')[1];
+        let keywordInfo = queryList[2].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10) + '1');
+        } else {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10 + 1) + '1');
+        }
+
+        sortString = '&sort=' + sortInfo;
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + sortString + keywordString;
+    } else if (!search.includes('page') && search.includes('sort') && search.includes('keyword')) {
+        let sortInfo = queryList[0].split('=')[1];
+        let keywordInfo = queryList[1].split('=')[1];
+
+        pageString = '/?page=11';
+        sortString = '&sort=' + sortInfo;
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + sortString + keywordString;
+    } else if (search.includes('page') && !search.includes('sort') && search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+        let keywordInfo = queryList[1].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10) + '1');
+        } else {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10 + 1) + '1');
+        }
+
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + keywordString;
+    } else if (search.includes('page') && search.includes('sort') && !search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+        let sortInfo = queryList[1].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10) + '1');
+        } else {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10 + 1) + '1');
+        }
+
+        sortString = '&sort=' + sortInfo;
+        location.href = pageString + sortString;
+    } else if (!search.includes('page') && !search.includes('sort') && search.includes('keyword')) {
+        let keywordInfo = queryList[0].split('=')[1];
+
+        pageString = '/?page=11';
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + keywordString;
+    } else if (!search.includes('page') && search.includes('sort') && !search.includes('keyword')) {
+        let sortInfo = queryList[0].split('=')[1];
+
+        pageString = '/?page=11';
+        sortString = '&sort=' + sortInfo;
+        location.href = pageString + sortString;
+    } else if (search.includes('page') && !search.includes('sort') && !search.includes('keyword')) {
+        let pageInfo = queryList[0].split('=')[1];
+
+        if (pageInfo % 10 === 0) {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10) + '1');
+        } else {
+            pageString = '/?page=' + (Math.floor(pageInfo / 10 + 1) + '1');
+        }
+
+        location.href = pageString;
+    } else {
+        location.href = '/?page=11';
+    }
+}
+
+function moveIdx(idx) {
+    let pageString = '';
+    let sortString = '';
+    let keywordString = '';
+
+    let search = location.search;
+    let queryList = search.split('&');
+
+    if (search.includes('page') && search.includes('sort') && search.includes('keyword')) {
+        let sortInfo = queryList[1].split('=')[1];
+        let keywordInfo = queryList[2].split('=')[1];
+
+        pageString = '/?page=' + idx;
+        sortString = '&sort=' + sortInfo;
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + sortString + keywordString;
+    } else if (!search.includes('page') && search.includes('sort') && search.includes('keyword')) {
+        let sortInfo = queryList[0].split('=')[1];
+        let keywordInfo = queryList[1].split('=')[1];
+
+        pageString = '/?page=' + idx;
+        sortString = '&sort=' + sortInfo;
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + sortString + keywordString;
+    } else if (search.includes('page') && !search.includes('sort') && search.includes('keyword')) {
+        let keywordInfo = queryList[1].split('=')[1];
+
+        pageString = '/?page=' + idx;
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + keywordString;
+    } else if (search.includes('page') && search.includes('sort') && !search.includes('keyword')) {
+        let sortInfo = queryList[1].split('=')[1];
+
+        pageString = '/?page=' + idx;
+        sortString = '&sort=' + sortInfo;
+        location.href = pageString + sortString;
+    } else if (!search.includes('page') && !search.includes('sort') && search.includes('keyword')) {
+        let keywordInfo = queryList[0].split('=')[1];
+
+        pageString = '/?page=' + idx;
+        keywordString = '&keyword=' + keywordInfo;
+        location.href = pageString + keywordString;
+    } else if (!search.includes('page') && search.includes('sort') && !search.includes('keyword')) {
+        let sortInfo = queryList[0].split('=')[1];
+
+        pageString = '/?page=' + idx;
+        sortString = '&sort=' + sortInfo;
+        location.href = pageString + sortString;
+    } else {
+        pageString = '/?page=' + idx;
+        location.href = pageString;
+    }
+}

--- a/src/main/resources/static/js/search/AboutStudy.js
+++ b/src/main/resources/static/js/search/AboutStudy.js
@@ -1,0 +1,4 @@
+// 1. 특정 스터디로 페이지 이동
+function moveToStudyDetailPage(studyId) {
+    location.href = '/study/' + Number(studyId);
+}

--- a/src/main/resources/static/js/search/SearchProcess.js
+++ b/src/main/resources/static/js/search/SearchProcess.js
@@ -1,0 +1,57 @@
+// 1. 기준에 따른 단순 검색
+function selectDate() {
+    let keyword = $('#keyword');
+
+    if (keyword.val().trim() === '') {
+        location.href = '/';
+    } else {
+        location.href = '/?keyword=' + keyword.val();
+    }
+}
+
+function selectPopularity() {
+    let keyword = $('#keyword');
+
+    if (keyword.val().trim() === '') {
+        location.href = '/?sort=popularity';
+    } else {
+        location.href = '/?sort=popularity&keyword=' + keyword.val();
+    }
+}
+
+function selectRecruitDeadLine() {
+    let keyword = $('#keyword');
+
+    if (keyword.val().trim() === '') {
+        location.href = '/?sort=recruitDeadline';
+    } else {
+        location.href = '/?sort=recruitDeadline&keyword=' + keyword.val();
+    }
+}
+
+function selectMaxMember() {
+    let keyword = $('#keyword');
+
+    if (keyword.val().trim() === '') {
+        location.href = '/?sort=maxMember';
+    } else {
+        location.href = '/?sort=maxMember&keyword=' + keyword.val();
+    }
+}
+
+// 2. 디테일 검색 (기준 + 키워드)
+function detailSearch(searchType, keyword) {
+    if (searchType === 'registerDate' ) {
+        if (keyword.trim() === '') {
+            location.href = '/';
+        } else {
+            location.href = '?keyword=' + keyword;
+        }
+    } else {
+        if (keyword.trim() === '') {
+            location.href = '?sort=' + searchType;
+        } else {
+            location.href = '?sort=' + searchType + '&keyword=' + keyword;
+        }
+    }
+}

--- a/src/main/webapp/WEB-INF/views/fragment/MainSection.jsp
+++ b/src/main/webapp/WEB-INF/views/fragment/MainSection.jsp
@@ -1,0 +1,9 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<section class="py-3 text-center container">
+    <div class="row py-lg-5">
+        <div class="col-lg-6 col-md-8 mx-auto">
+            <h1 class="fw-light">스터디를 찾아보세요!!</h1>
+            <p class="lead text-muted">자신이 관심있어 하는 분야와 관련된 스터디를 찾고<br> 해당 스터디에 참여해보세요</p>
+        </div>
+    </div>
+</section>

--- a/src/main/webapp/WEB-INF/views/fragment/MainStudy.jsp
+++ b/src/main/webapp/WEB-INF/views/fragment/MainStudy.jsp
@@ -1,0 +1,60 @@
+<%@ page import="java.util.List" %>
+<%@ page import="com.sjiwon.studyholic.domain.entity.study.service.dto.response.StudySimpleInformation" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<script src="<c:url value="/js/search/AboutStudy.js"/>"></script>
+<%
+    List<StudySimpleInformation> studyList = (List<StudySimpleInformation>) request.getAttribute("studyList");
+%>
+<style>
+    .tag {
+        border-radius: 10%;
+        background: beige;
+        font-size: 13px;
+        font-style: italic;
+        font-weight: bold;
+        margin: 2px;
+        padding: 2px;
+    }
+</style>
+<div class="album py-5 bg-light">
+    <div class="container">
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+            <c:forEach begin="0" end="<%=studyList.size()%>" var="study" items="<%=studyList%>">
+                <div class="col">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3 style="text-align: center">${study.studyName}</h3>
+                        </div>
+
+                        <div class="card-body">
+                            <p class="card-text" style="font-size: 20px; font-weight: bold;">${study.studyBriefDescription}</p>
+                            <p class="card-text">스터디 리더 |
+                                <span>
+                                    <img src="<c:out value="/images/user/${study.studyLeaderImage}"/>" alt="test" width="30" height="30" style="border-radius: 25%; margin: 3px;"/>
+                                    <b style="text-align: center; margin: 3px;">${study.studyLeaderNickname}</b>
+                                </span>
+                            </p>
+                            <p class="card-text">모집 현황 | ${study.studyCurrentMemberCount} / ${study.studyMaxMemberCount}</p>
+                            <p class="card-text">모집 마감일 | ${study.studyRecruitDeadLine}</p>
+
+                            <c:forEach var="tag" items="${study.studyTagList}">
+                                <span class="tag" style="font-weight: bold"># ${tag}</span>
+                            </c:forEach>
+                        </div>
+
+                        <div class="card-footer">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div>
+                                    <button type="button" class="btn btn-sm btn-primary" style="margin: 2px;" onclick="moveToStudyDetailPage(${study.studyId})">상세정보</button>
+                                </div>
+                                <small class="text-muted">등록 | ${study.registerDateFromCurrentDate}</small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </c:forEach>
+        </div>
+    </div>
+</div>

--- a/src/main/webapp/WEB-INF/views/fragment/StudySearch.jsp
+++ b/src/main/webapp/WEB-INF/views/fragment/StudySearch.jsp
@@ -1,0 +1,56 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<script src="<c:url value="/js/search/SearchProcess.js"/>"></script>
+<%
+    String searchType = request.getParameter("searchType");
+    String keyword = request.getParameter("keyword");
+%>
+<div class="d-flex justify-content-center align-items-center flex-row">
+    <div>
+        <div class="input-group mb-3">
+            <button id="searchType" type="button" class="btn btn-outline-primary"><%=searchType%>
+            </button>
+            <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="visually-hidden"></span>
+            </button>
+            <ul class="dropdown-menu">
+                <li>
+                    <button id="registerDate" class="dropdown-item" type="button" value="registerDate" onclick="selectDate()">등록 날짜</button>
+                </li>
+                <li>
+                    <button id="popularity" class="dropdown-item" type="button" value="popularity" onclick="selectPopularity()">참여 인원</button>
+                </li>
+                <li>
+                    <button id="recruitDeadLine" class="dropdown-item" type="button" value="recruitDeadline" onclick="selectRecruitDeadLine()">모집 마감일</button>
+                </li>
+                <li>
+                    <button id="maxMember" class="dropdown-item" type="button" value="maxMember" onclick="selectMaxMember()">모집 정원</button>
+                </li>
+            </ul>
+            <input id="keyword" type="text" class="form-control" placeholder="Search... Enter" value="<%=keyword%>"/>
+        </div>
+    </div>
+</div>
+
+<script>
+    let searchType = $('#searchType');
+    let keyword = $('#keyword');
+
+    keyword.on('keydown', function (event) {
+        let key = event.key || event.keyCode;
+
+        if (key === 'Enter' || key === 13) {
+            event.preventDefault();
+
+            if (searchType.html() === '등록 날짜') {
+                detailSearch('registerDate', keyword.val());
+            } else if (searchType.html() === '참여 인원') {
+                detailSearch('popularity', keyword.val());
+            } else if (searchType.html() === '모집 마감일') {
+                detailSearch('recruitDeadline', keyword.val());
+            } else { // 모집 정원
+                detailSearch('maxMember', keyword.val());
+            }
+        }
+    });
+</script>

--- a/src/main/webapp/WEB-INF/views/main/MainPage.jsp
+++ b/src/main/webapp/WEB-INF/views/main/MainPage.jsp
@@ -1,0 +1,47 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Studyholic</title>
+    <%@ include file="../util/resources.jsp" %>
+    <script src="<c:url value="/js/paging/Paging.js"/>"></script>
+</head>
+<body>
+<c:choose>
+    <c:when test="${sessionScope.KGU_JSP_PROJECT == null}">
+        <jsp:include page="../fragment/AnonymousHeader.jsp"/>
+    </c:when>
+    <c:when test="${sessionScope.KGU_JSP_PROJECT != null}">
+        <jsp:include page="../fragment/AuthenticateHeader.jsp"/>
+    </c:when>
+</c:choose>
+<jsp:include page="../fragment/MainSection.jsp"/>
+<jsp:include page="../fragment/StudySearch.jsp">
+    <jsp:param name="searchType" value="${searchType}"/>
+    <jsp:param name="keyword" value="${keyword}"/>
+</jsp:include>
+<jsp:include page="../fragment/MainStudy.jsp">
+    <jsp:param name="studyList" value="${studyList}"/>
+</jsp:include>
+<ul class="pagination justify-content-center pagination-circle">
+    <c:if test="${pagination.prev}">
+        <li class="page-item">
+            <button class="page-link" type="button" onclick="movePreviousRange()">Previous</button>
+        </li>
+    </c:if>
+
+    <c:forEach var="idx" begin="${pagination.rangeStartNumber}" end="${pagination.rangeEndNumber}">
+        <li class="page-item <c:out value="${pagination.currentPage == idx ? 'active' : ''}"/> ">
+            <button class="page-link" type="button" onclick="moveIdx('${idx}')">${idx}</button>
+        </li>
+    </c:forEach>
+
+    <c:if test="${pagination.next}">
+        <li class="page-item">
+            <button class="page-link" type="button" onclick="moveNextRange()">Next</button>
+        </li>
+    </c:if>
+</ul>
+<jsp:include page="../fragment/Footer.jsp"/>
+</body>
+</html>


### PR DESCRIPTION
## View
- <code>Header</code> : 로그인 여부에 따라 <code>AnonymousHeader / AuthenticationHeader</code>로 구분
- <code>MainSection</code> : 웹 플랫폼에 대한 간단한 설명
- <code>StudySearch</code> : 스터디에 대한 검색을 할 수 있는 fragment
    - 기본 검색 [등록 날짜 / 참여 인원 / 모집 마감일 / 모집 정원]
    - 키워드 추가 검색
- <code>MainStudy</code> : 현재 페이징 기준(6개)의 스터디 페이징 데이터를 화면에 출력
- <code>Pagination Button List</code> : 서비스 상의 스터디 출력 자체를 Pagination으로 구현

> 메인 페이지로 URL 요청을 하게 되면 기본적으로 <code>page, sort, keyword</code>의 파라미터를 받을 수 있고 여기서 keyword는 필수값이 아님

<br>

## API
- 페이징에 의한 스터디 페이징 데이터 쿼리 구현

